### PR TITLE
Use toolchain variables from execution environment if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG_ARCH=x86_64
 PKG_ARCH_RPM=x86_64
 
 TARGET=$(PKG_NAME)
-PREFIX:=/usr
+PREFIX?=/usr
 CC:=gcc
 #CFLAGS:=-g -Wall
 CCFLAGS:=-O3 -fpie
@@ -37,11 +37,6 @@ clean:
 	-rm -f $(TARGET)
 	-rm -f *.deb *.rpm
 	#-rm -f ../${UPSTREAM_PACKAGE}
-
-# PREFIX is environment variable, but if it is not set, then set default value
-ifeq ($(PREFIX),)
-	PREFIX := /usr
-endif
 
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ PKG_ARCH_RPM=x86_64
 
 TARGET=$(PKG_NAME)
 PREFIX?=/usr
-CC:=gcc
-#CFLAGS:=-g -Wall
-CCFLAGS:=-O3 -fpie
-CFLAGS:=-O3 -fpie
+CC?=gcc
+#CFLAGS?=-g -Wall
+CCFLAGS?=-O3 -fpie
+CFLAGS?=-O3 -fpie
 
 
 .PHONY: default all clean


### PR DESCRIPTION
This PR patches the Makefile such that toolchain environment variables (`CC`, `CFLAGS`, ...) take precedence over the default values in the Makefile. This makes the work of distribution packagers more easy as the values don't have to be explicitly specified in the call of `make`.